### PR TITLE
Added the 'subtree' requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ A little gulp module to let you push a folder to a git subtree without keeping t
 
 In order for Gulp Subtree to work correctly, the folder you are pushing **MUST NOT BE IGNORED THROUGH GIT**. Often, this is the `dist` folder. This is because Gulp Subtree needs to be able to temporarly add it to your Git repository in order to push it. For this reason, it's recommended to pair with [gulp-clean](https://www.npmjs.org/package/gulp-clean), allowing your distribution folder to be totally removed after it's been pushed.
 
+## Requirements
+
+`git subtree` must be previously installed. Older versions of `git` (e.g. Ubuntu 12.04's standard install version) are not bundled with it. The easiest way to check is to see if `git subtree` throws up or not. Gulp will fail silently if the command is not available. See [here](http://engineeredweb.com/blog/how-to-install-git-subtree/) for more info on how to install it.
+
 ## Usage
 
 ```js


### PR DESCRIPTION
Part two of getting `gulp deploy` to work for others. 

`gulp-subtree` will fail silently, without so much as a hint, if `git subtree` is not a valid command (oh javascript). Installing it is pretty simple, I used the link attached, but non-standard in some places.
