### PR TITLE
add skipCommit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ gulp.task('subtree', function () {
 ## Options
 
 Options can be passed into subtree to choose the remote, branch, and message to push with. By default, it's `origin`, `gh-pages`, and `'Distribution Commit'`.
+By default gulp subtree creates a temporary commit to pick up any generated files.  Use the skipCommit flag if you wish to skip this.
 
 ```js
 var subtree = require('gulp-subtree');
@@ -37,7 +38,8 @@ gulp.task('subtree', function () {
     .pipe(subtree({
       remote: 'upstream',
       branch: 'master',
-      message: 'Here We Go!'
+      message: 'Here We Go!',
+      skipCommit: false
     }))
     .pipe(clean());
 });

--- a/index.js
+++ b/index.js
@@ -14,6 +14,37 @@ function execute(command, callback){
 
 module.exports = function (options) {
   return es.map(function (file, cb) {
+    //////////////////////////////
+    // Finish Deploy
+    //////////////////////////////
+    var deployStart = function() {
+      execute('git ls-remote ' + remote + ' ' + branch, function (rmt) {
+        if (rmt.length > 0) {
+          gutil.log('Cleaning ' + chalk.cyan(remote) + '/' + chalk.cyan(branch));
+          execute('git push ' + remote + ' :' + branch, function () {
+            deployFinish();
+          });
+        }
+        else {
+          deployFinish();
+        }
+      });
+    };
+
+    //////////////////////////////
+    // Finish Deploy
+    //////////////////////////////
+    var deployFinish = function () {
+      gutil.log('Pushing ' + chalk.magenta(folder) + ' to ' + chalk.cyan(remote) + '/' + chalk.cyan(branch));
+      execute('git subtree push --prefix ' + folder + ' ' + remote + ' ' + branch, function () {
+        if (!skipCommit) {
+          gutil.log('Resetting ' + chalk.magenta(folder) + ' temporary commit');
+          execute('git reset HEAD^', function () {
+            return cb(null, file);
+          });
+        }
+      });
+    };
 
     //////////////////////////////
     // Does not work with buffers
@@ -30,41 +61,21 @@ module.exports = function (options) {
     var remote = 'origin';
     var branch = 'gh-pages';
     var message = 'Distribution Commit';
+    var skipCommit = false;
     if (options !== undefined) {
       remote = options.remote || remote;
       branch = options.branch || branch;
       message = options.message || message;
+      skipCommit = options.skipCommit || skipCommit;
     }
 
-
-
-    // execute('git add ' + folder, function () {
-    execute('git add ' + folder + ' && git commit -m "' + message + '"', function () {
-      gutil.log('Temporarily committing ' + chalk.magenta(folder));
-      execute('git ls-remote ' + remote + ' ' + branch, function (rmt) {
-        if (rmt.length > 0) {
-          gutil.log('Cleaning ' + chalk.cyan(remote) + '/' + chalk.cyan(branch));
-          execute('git push ' + remote + ' :' + branch, function () {
-            deployFinish();
-          });
-        }
-        else {
-          deployFinish();
-        }
+    if (!skipCommit) {
+      execute('git add ' + folder + ' && git commit -m "' + message + '"', function () {
+        gutil.log('Temporarily committing ' + chalk.magenta(folder));
+        deployStart();
       });
-    });
-
-    //////////////////////////////
-    // Finish Deploy
-    //////////////////////////////
-    var deployFinish = function () {
-      gutil.log('Pushing ' + chalk.magenta(folder) + ' to ' + chalk.cyan(remote) + '/' + chalk.cyan(branch));
-      execute('git subtree push --prefix ' + folder + ' ' + remote + ' ' + branch, function () {
-        gutil.log('Resetting ' + chalk.magenta(folder) + ' temporary commit');
-        execute('git reset HEAD^', function () {
-          return cb(null, file);
-        });
-      });
-    };
+    } else {
+      deployStart();
+    }
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-subtree",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Gulp module to push a folder to a subtree",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
First off, very cool gulp plugin.

There are projects where nothing is 'compiled' as part of the process of publishing the code.  In these cases, because there are no changes gulp-subtree tries to do a commit (which fails) and then resets HEAD~1 (which unstages the last commit).  To get around this I'd like to propose a skipCommit option that can be used for projects that require no additional compilation.

Please let me know what you think.

- mike  