### PR TITLE
Show errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var chalk = require('chalk');
 // Execute with Callback
 //////////////////////////////
 function execute(command, callback){
-  exec(command, function(error, stdout, stderr){ callback(stdout); });
+  exec(command, function(error, stdout, stderr){ callback(error, stdout); });
 };
 
 module.exports = function (options) {
@@ -39,12 +39,21 @@ module.exports = function (options) {
 
 
     // execute('git add ' + folder, function () {
-    execute('git add ' + folder + ' && git commit -m "' + message + '"', function () {
+    execute('git add ' + folder + ' && git commit -m "' + message + '"', function (error) {
+      if (error) {
+        return cb(error);
+      }
       gutil.log('Temporarily committing ' + chalk.magenta(folder));
-      execute('git ls-remote ' + remote + ' ' + branch, function (rmt) {
+      execute('git ls-remote ' + remote + ' ' + branch, function (error, rmt) {
+        if (error) {
+          return cb(error);
+        }
         if (rmt.length > 0) {
           gutil.log('Cleaning ' + chalk.cyan(remote) + '/' + chalk.cyan(branch));
-          execute('git push ' + remote + ' :' + branch, function () {
+          execute('git push ' + remote + ' :' + branch, function (error) {
+            if (error) {
+              return cb(error);
+            }
             deployFinish();
           });
         }
@@ -59,10 +68,13 @@ module.exports = function (options) {
     //////////////////////////////
     var deployFinish = function () {
       gutil.log('Pushing ' + chalk.magenta(folder) + ' to ' + chalk.cyan(remote) + '/' + chalk.cyan(branch));
-      execute('git subtree push --prefix ' + folder + ' ' + remote + ' ' + branch, function () {
+      execute('git subtree push --prefix ' + folder + ' ' + remote + ' ' + branch, function (error) {
+        if (error) {
+          return cb(error);
+        }
         gutil.log('Resetting ' + chalk.magenta(folder) + ' temporary commit');
-        execute('git reset HEAD^', function () {
-          return cb(null, file);
+        execute('git reset HEAD^', function (error) {
+          return cb(error, file);
         });
       });
     };


### PR DESCRIPTION
Break when throw errors.
Example error:

```
Error: Command failed: /bin/sh -c git add client/build && git commit -m "Distribution Commit"
The following paths are ignored by one of your .gitignore files:
client/build
Use -f if you really want to add them.
```
